### PR TITLE
Visualizing any JSON file in the current directory

### DIFF
--- a/display/index.html
+++ b/display/index.html
@@ -29,7 +29,7 @@ and available here:
     font-size: 15px;
   }
   </style>
-  <script>
+  <script type="text/javascript">
 
   json_fname = "attn_vis_data.json" // file containing the text and the weights
 
@@ -164,6 +164,11 @@ and available here:
   }
 
   function get_json_and_disp() {
+    
+    selected = $("#file-select option:selected");
+    if (selected.length > 0){
+        json_fname = selected.first().text();
+    }
     // Retrieve the json data file and display the data
     console.log("fetching " + json_fname + "...")
 
@@ -186,9 +191,21 @@ and available here:
     $.getJSON(json_fname, json_success).fail(json_fail);
   }
 
+  function get_file_list() {
+    $.get('/!list', function (data){
+        if (data){
+            data = data.split("\n");
+            $.each(data, function(index, value){
+                $("#file-select").append("<option value=\"" + value  + "\">" + value + "</option>");
+            });
+        }
+        get_json_and_disp()
+    });
+  }
+
   function start() {
     console.log("start")
-    get_json_and_disp()
+    get_file_list()
 
     // Define a tooltip that we will use to display generation probability of a decoder word when you hover over it
     var tooltip = d3.select("body")
@@ -207,6 +224,9 @@ and available here:
   </head>
   <body onload="start();">
     <div id="wrap">
+      <div id="select">
+        Select file to display: <select id="file-select" onchange="get_json_and_disp()"></select>
+      </div>
       <div id="curr_datafile">
         Current datafile name goes here.
       </div>

--- a/display/run_service.sh
+++ b/display/run_service.sh
@@ -1,1 +1,3 @@
-python -m SimpleHTTPServer
+#!/bin/sh
+
+python3 service.py $1

--- a/display/service.py
+++ b/display/service.py
@@ -1,0 +1,31 @@
+#!/usr/bin/env python3
+
+
+import glob
+import http.server
+import socketserver
+from argparse import ArgumentParser
+
+
+class MyHTTPHandler(http.server.SimpleHTTPRequestHandler):
+
+    def do_GET(self):
+        if self.path == '/!list':  # provide newline-separated listing of JSON files in the current directory
+            self.send_response(200)
+            self.send_header("Content-type", "text/plain")
+            self.end_headers()
+            response = "\n".join(glob.glob("*.json"))
+            self.wfile.write(response.encode())
+        else:  # default: provide the file
+            super().do_GET()
+
+
+if __name__ == '__main__':
+    ap = ArgumentParser()
+    ap.add_argument('port', nargs='?', default=8000, type=int)
+
+    args = ap.parse_args()
+
+    with socketserver.TCPServer(("", args.port), MyHTTPHandler) as httpd:
+        print("serving at port", args.port)
+        httpd.serve_forever()


### PR DESCRIPTION
Now the service will read a list of all `*.json` files in the current directory on page load, and you can choose which one to display using a select box on top. You need to reload the page to update the file list.